### PR TITLE
prevent the card height

### DIFF
--- a/static/css/event_details.css
+++ b/static/css/event_details.css
@@ -255,7 +255,37 @@
 }
 
 /* List items */
-.list-area { display: grid; gap: 10px; }
+.list-area {
+  display: grid;
+  gap: 10px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0,0,0,0.15) transparent;
+}
+
+.list-area::-webkit-scrollbar {
+  width: 5px;
+}
+
+.list-area::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.list-area::-webkit-scrollbar-thumb {
+  background: rgba(0,0,0,0.15);
+  border-radius: 999px;
+}
+
+.list-area::-webkit-scrollbar-thumb:hover {
+  background: rgba(0,0,0,0.25);
+}
+
+/* Per-panel scroll height overrides */
+.panel-task         .list-area { max-height: 280px; }
+.panel-timeline     .list-area { max-height: 240px; }
+.panel-participants .list-area { max-height: 260px; }
 
 .empty-state {
   color: #9ca3af;
@@ -556,28 +586,17 @@
   border-radius: 999px;
   letter-spacing: 0.03em;
 }
-
-.role-tag {
-  display: inline-block;
+/* Admin toggle button */
+.toggle-admin {
+  border: none;
   border-radius: 999px;
-  padding: 2px 10px;
-  font-size: 0.72rem;
-  font-weight: 800;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
+  padding: 7px 13px;
+  font-family: "Poppins", sans-serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+  background: #dbe6ff;
+  color: #2554d8;
+  transition: background 0.2s;
 }
-
-.role-host {
-  background: #dbeafe;
-  color: #1d4ed8;
-}
-
-.role-co_host {
-  background: #f3e8ff;
-  color: #7e22ce;
-}
-
-.role-participant {
-  background: #e5e7eb;
-  color: #374151;
-}
+.toggle-admin:hover { background: #bfcfff; }


### PR DESCRIPTION
## Description

Previously, the Task Board, Timeline, and Participants panels on the Event Details page would grow indefinitely as more items were added, causing the cards to become excessively tall and breaking the page layout. This PR adds a maximum height and smooth scrolling to each panel's list area so the layout remains consistent regardless of how many items are present.