### PR TITLE
Secure config, refactor templates, and stabilize Selenium tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+SECRET_KEY=your-secret-key

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ env/
 
 # Testing
 .pytest_cache/
+.selenium-cache/
+tests/seleniumtest/.wdm/
+chrome-test.*/
 
 # Database
 instance/

--- a/README.md
+++ b/README.md
@@ -58,21 +58,22 @@ The project includes:
 ### Run all tests
 
 ```bash
-PYTHONPATH=. python -m pytest tests
+PYTHONPATH=. python -m pytest
 ```
 
 ### Run unit tests only
 
 ```bash
-PYTHONPATH=. python -m pytest tests/test_forms.py tests/test_routes.py tests/test_usermodels.py
+PYTHONPATH=. python -m pytest tests/unittest
 ```
 
 ### Run Selenium tests
 
-(make sure the server is running)
+The Selenium tests start a live Flask test server automatically. They require
+Google Chrome to be installed locally.
 
 ```bash
-PYTHONPATH=. python -m pytest tests/test_selenium.py
+PYTHONPATH=. python -m pytest tests/seleniumtest
 ```
 
 ---

--- a/app.py
+++ b/app.py
@@ -16,7 +16,10 @@ load_dotenv()
 
 app = Flask(__name__)
 
-app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "dev-secret-key")
+secret_key = os.environ.get("SECRET_KEY")
+if not secret_key:
+    raise RuntimeError("SECRET_KEY environment variable must be set.")
+app.config["SECRET_KEY"] = secret_key
 
 app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
     "DATABASE_URL",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,8 @@
 [pytest]
+testpaths =
+    tests/unittest
+    tests/seleniumtest
+python_files = test_*.py
 filterwarnings =
     ignore::DeprecationWarning
     ignore::sqlalchemy.exc.LegacyAPIWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,11 @@ Pygments==2.20.0
 pytest==9.0.3
 python-dotenv==1.2.2
 requests==2.33.1
+selenium==4.43.0
 SQLAlchemy==2.0.49
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.6.3
 Werkzeug==3.1.8
 Flask-WTF==1.2.1
+webdriver-manager==4.0.2

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  {% block csrf_meta %}{% endblock %}
+  <title>{% block title %}Eventure{% endblock %}</title>
+
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script src="https://unpkg.com/lucide@latest"></script>
+
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
+  {% block styles %}{% endblock %}
+  {% block head_scripts %}{% endblock %}
+</head>
+
+<body{% block body_attrs %}{% endblock %}>
+{% block content %}{% endblock %}
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,19 +1,21 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+{% extends "base.html" %}
+
+{% block title %}My Events{% endblock %}
+
+{% block csrf_meta %}
   <meta name="csrf-token" content="{{ csrf_token() }}">
-  <title>My Events</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
+{% endblock %}
+
+{% block styles %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
-  <script src="https://unpkg.com/lucide@latest"></script>
+{% endblock %}
+
+{% block head_scripts %}
   <script src="{{ url_for('static', filename='js/csrf.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/dashboard.js') }}" defer></script>
-</head>
+{% endblock %}
 
-<body>
+{% block content %}
   <div class="container">
 
     <!-- TOPBAR -->
@@ -220,5 +222,4 @@
     </div>
   </div>
 
-</body>
-</html>
+{% endblock %}

--- a/templates/discover.html
+++ b/templates/discover.html
@@ -1,19 +1,22 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+{% extends "base.html" %}
+
+{% block title %}Discover Events{% endblock %}
+
+{% block csrf_meta %}
   <meta name="csrf-token" content="{{ csrf_token() }}">
-  <title>Discover Events</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
+{% endblock %}
+
+{% block styles %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/discover.css') }}">
-  <script src="https://unpkg.com/lucide@latest"></script>
+{% endblock %}
+
+{% block head_scripts %}
   <script src="{{ url_for('static', filename='js/csrf.js') }}" defer></script>
   <script src="{{ url_for('static', filename='js/discover.js') }}" defer></script>
-</head>
-<body>
+{% endblock %}
+
+{% block content %}
 
 <div class="container">
 
@@ -116,5 +119,4 @@
   </div>
 
 </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/event_details.html
+++ b/templates/event_details.html
@@ -1,22 +1,16 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+{% extends "base.html" %}
+
+{% block title %}Event Details{% endblock %}
+
+{% block csrf_meta %}
   <meta name="csrf-token" content="{{ csrf_token() }}">
-  <title>Event Details</title>
+{% endblock %}
 
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet"/>
-
-  <script src="https://unpkg.com/lucide@latest"></script>
-
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
+{% block styles %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/event_details.css') }}">
-</head>
+{% endblock %}
 
-<body
+{% block body_attrs %}
   data-event-id="{{ event.id }}"
   data-current-role="{{ current_role or '' }}"
   data-can-edit="{{ 'true' if can_edit else 'false' }}"
@@ -24,7 +18,9 @@
   data-can-assign-roles="{{ 'true' if can_assign_roles else 'false' }}"
   data-can-vote="{{ 'true' if can_vote else 'false' }}"
   data-is-public="{{ 'true' if event.is_public else 'false' }}"
->
+{% endblock %}
+
+{% block content %}
 <div class="page-wrapper">
 
   <!-- TOPBAR -->
@@ -297,7 +293,9 @@
   </div>
 </div>
 
+{% endblock %}
+
+{% block scripts %}
 <script src="{{ url_for('static', filename='js/csrf.js') }}"></script>
 <script src="{{ url_for('static', filename='js/event_details.js') }}"></script>
-</body>
-</html>
+{% endblock %}

--- a/templates/invitation_page.html
+++ b/templates/invitation_page.html
@@ -1,21 +1,16 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+{% extends "base.html" %}
+
+{% block title %}Invitations{% endblock %}
+
+{% block csrf_meta %}
   <meta name="csrf-token" content="{{ csrf_token() }}">
-  <title>Invitations</title>
+{% endblock %}
 
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&display=swap" rel="stylesheet"/>
-
-  <script src="https://unpkg.com/lucide@latest"></script>
-
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
+{% block styles %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/invitation_page.css') }}">
-</head>
-<body>
+{% endblock %}
+
+{% block content %}
 <div class="page-wrapper">
 
   <!-- TOPBAR -->
@@ -132,8 +127,9 @@
     </div>
   </div>
 </div>
+{% endblock %}
 
+{% block scripts %}
 <script src="{{ url_for('static', filename='js/csrf.js') }}"></script>
 <script src="{{ url_for('static', filename='js/invitation_page.js') }}"></script>
-</body>
-</html>
+{% endblock %}

--- a/templates/login_signup.html
+++ b/templates/login_signup.html
@@ -1,19 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Eventure — Login</title>
+{% extends "base.html" %}
 
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;800&display=swap" rel="stylesheet">
+{% block title %}Eventure — Login{% endblock %}
 
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
+{% block styles %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/login_signup.css') }}">
+{% endblock %}
 
-  <script src="https://unpkg.com/lucide@latest"></script>
-</head>
-
-<body>
+{% block content %}
   <div class="container">
 
     <div class="logo-wrapper">
@@ -111,8 +104,9 @@
     {% endif %}
 
   </div>
+{% endblock %}
 
+{% block scripts %}
   <script src="{{ url_for('static', filename='js/login_signup.js') }}"></script>
   <script>lucide.createIcons();</script>
-</body>
-</html>
+{% endblock %}

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,18 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
+{% extends "base.html" %}
+
+{% block title %}Profile &amp; Settings{% endblock %}
+
+{% block csrf_meta %}
   <meta name="csrf-token" content="{{ csrf_token() }}">
-  <title>Profile &amp; Settings</title>
+{% endblock %}
 
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700;800&display=swap" rel="stylesheet">
-  <script src="https://unpkg.com/lucide@latest"></script>
-
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/global.css') }}">
+{% block styles %}
   <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
-</head>
-<body>
+{% endblock %}
+
+{% block content %}
 
 <div class="container">
 
@@ -105,7 +104,9 @@
   </div><!-- /cards-row -->
 
 </div>
+{% endblock %}
 
+{% block scripts %}
 <script>
   // Initialize from backend (Jinja)
   window.userData = {
@@ -123,6 +124,4 @@
   document.getElementById("emailInput").value = window.userData.email;
   lucide.createIcons();
 </script>
-
-</body>
-</html>
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from werkzeug.security import generate_password_hash
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, BASE_DIR)
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
 
 from app import app
 from models import db, User, Event, Participant, Invitation

--- a/tests/seleniumtest/conftest.py
+++ b/tests/seleniumtest/conftest.py
@@ -8,30 +8,19 @@ from urllib.request import urlopen
 
 import pytest
 from selenium import webdriver
-from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.chrome.service import Service
-from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.edge.options import Options as EdgeOptions
 from werkzeug.serving import make_server
 
 os.environ.setdefault("SECRET_KEY", "selenium-test-secret-key")
 
 from app import app
+from models import db
 
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 os.environ.setdefault("SE_CACHE_PATH", os.path.join(BASE_DIR, ".selenium-cache"))
 os.environ.setdefault("WDM_LOCAL", "1")
-
-
-def _chromedriver_path():
-    cached_drivers = sorted(
-        Path(BASE_DIR).glob("tests/seleniumtest/.wdm/**/chromedriver")
-    )
-    if cached_drivers:
-        return str(cached_drivers[-1])
-
-    return ChromeDriverManager().install()
 
 
 def _free_port():
@@ -40,61 +29,79 @@ def _free_port():
         return sock.getsockname()[1]
 
 
+def _browser_options(options_class, profile_dir):
+    options = options_class()
+    options.add_argument("--headless=new")
+    options.add_argument("--window-size=1440,1000")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--no-first-run")
+    options.add_argument("--disable-background-networking")
+    options.add_argument("--disable-extensions")
+    options.add_argument("--disable-popup-blocking")
+    options.add_argument("--remote-debugging-port=0")
+    options.add_argument(f"--user-data-dir={profile_dir}")
+    return options
+
+
 @pytest.fixture(scope="session")
 def live_server_url():
-    app.config.update(
-        TESTING=True,
-        SECRET_KEY="selenium-test-secret-key",
-    )
+    with tempfile.TemporaryDirectory(dir=BASE_DIR) as db_dir:
+        test_db_path = Path(db_dir) / "selenium-test.db"
+        app.config.update(
+            TESTING=True,
+            SECRET_KEY="selenium-test-secret-key",
+            SQLALCHEMY_DATABASE_URI=f"sqlite:///{test_db_path}",
+        )
 
-    port = _free_port()
-    server = make_server("127.0.0.1", port, app)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
+        with app.app_context():
+            db.drop_all()
+            db.create_all()
 
-    base_url = f"http://127.0.0.1:{port}"
-    for _ in range(30):
-        try:
-            urlopen(f"{base_url}/login", timeout=1)
-            break
-        except Exception:
-            time.sleep(0.1)
-    else:
+        port = _free_port()
+        server = make_server("127.0.0.1", port, app)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        base_url = f"http://127.0.0.1:{port}"
+        for _ in range(30):
+            try:
+                urlopen(f"{base_url}/login", timeout=1)
+                break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            server.shutdown()
+            pytest.fail("Selenium live server did not start")
+
+        yield base_url
+
         server.shutdown()
-        pytest.fail("Selenium live server did not start")
+        thread.join(timeout=2)
 
-    yield base_url
-
-    server.shutdown()
-    thread.join(timeout=2)
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
 
 
 @pytest.fixture
 def driver():
     with tempfile.TemporaryDirectory(dir=BASE_DIR) as profile_dir:
-        options = Options()
-        chrome_binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-        if not os.path.exists(chrome_binary):
-            pytest.fail("Google Chrome is required for Selenium tests.")
-
-        options.binary_location = chrome_binary
-        options.add_argument("--headless=new")
-        options.add_argument("--window-size=1440,1000")
-        options.add_argument("--no-sandbox")
-        options.add_argument("--disable-dev-shm-usage")
-        options.add_argument("--disable-gpu")
-        options.add_argument("--no-first-run")
-        options.add_argument("--disable-background-networking")
-        options.add_argument("--disable-extensions")
-        options.add_argument("--disable-popup-blocking")
-        options.add_argument("--remote-debugging-port=0")
-        options.add_argument(f"--user-data-dir={profile_dir}")
-
+        errors = []
         try:
-            service = Service(_chromedriver_path())
-            browser = webdriver.Chrome(service=service, options=options)
+            browser = webdriver.Chrome(options=_browser_options(Options, profile_dir))
         except Exception as exc:
-            pytest.skip(f"Chrome could not start in this environment: {exc}")
+            errors.append(f"Chrome: {exc}")
+            try:
+                browser = webdriver.Edge(options=_browser_options(EdgeOptions, profile_dir))
+            except Exception as edge_exc:
+                errors.append(f"Edge: {edge_exc}")
+                pytest.skip(
+                    "Selenium requires a local browser engine. "
+                    "Install Chrome or use Windows built-in Edge. "
+                    + " | ".join(errors)
+                )
 
         try:
             yield browser

--- a/tests/seleniumtest/conftest.py
+++ b/tests/seleniumtest/conftest.py
@@ -1,0 +1,102 @@
+import os
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+from urllib.request import urlopen
+
+import pytest
+from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+from webdriver_manager.chrome import ChromeDriverManager
+from werkzeug.serving import make_server
+
+os.environ.setdefault("SECRET_KEY", "selenium-test-secret-key")
+
+from app import app
+
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+os.environ.setdefault("SE_CACHE_PATH", os.path.join(BASE_DIR, ".selenium-cache"))
+os.environ.setdefault("WDM_LOCAL", "1")
+
+
+def _chromedriver_path():
+    cached_drivers = sorted(
+        Path(BASE_DIR).glob("tests/seleniumtest/.wdm/**/chromedriver")
+    )
+    if cached_drivers:
+        return str(cached_drivers[-1])
+
+    return ChromeDriverManager().install()
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def live_server_url():
+    app.config.update(
+        TESTING=True,
+        SECRET_KEY="selenium-test-secret-key",
+    )
+
+    port = _free_port()
+    server = make_server("127.0.0.1", port, app)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+    for _ in range(30):
+        try:
+            urlopen(f"{base_url}/login", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        server.shutdown()
+        pytest.fail("Selenium live server did not start")
+
+    yield base_url
+
+    server.shutdown()
+    thread.join(timeout=2)
+
+
+@pytest.fixture
+def driver():
+    with tempfile.TemporaryDirectory(dir=BASE_DIR) as profile_dir:
+        options = Options()
+        chrome_binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        if not os.path.exists(chrome_binary):
+            pytest.fail("Google Chrome is required for Selenium tests.")
+
+        options.binary_location = chrome_binary
+        options.add_argument("--headless=new")
+        options.add_argument("--window-size=1440,1000")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        options.add_argument("--disable-gpu")
+        options.add_argument("--no-first-run")
+        options.add_argument("--disable-background-networking")
+        options.add_argument("--disable-extensions")
+        options.add_argument("--disable-popup-blocking")
+        options.add_argument("--remote-debugging-port=0")
+        options.add_argument(f"--user-data-dir={profile_dir}")
+
+        try:
+            service = Service(_chromedriver_path())
+            browser = webdriver.Chrome(service=service, options=options)
+        except Exception as exc:
+            pytest.skip(f"Chrome could not start in this environment: {exc}")
+
+        try:
+            yield browser
+        finally:
+            browser.quit()

--- a/tests/seleniumtest/test_basic_ui.py
+++ b/tests/seleniumtest/test_basic_ui.py
@@ -1,0 +1,51 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+def wait_for_page(driver):
+    return WebDriverWait(driver, 5)
+
+
+def test_login_page_loads(driver, live_server_url):
+    driver.get(f"{live_server_url}/login")
+
+    page = driver.page_source
+    assert "Eventure" in page
+    assert "Log In" in page
+    assert "Sign Up" in page
+
+
+def test_login_form_contains_csrf_token(driver, live_server_url):
+    driver.get(f"{live_server_url}/login")
+
+    csrf_input = driver.find_element(By.NAME, "csrf_token")
+    assert csrf_input.get_attribute("type") == "hidden"
+    assert csrf_input.get_attribute("value")
+
+
+def test_signup_toggle_shows_signup_fields(driver, live_server_url):
+    driver.get(f"{live_server_url}/login")
+
+    driver.find_element(By.ID, "signupBtn").click()
+    wait_for_page(driver).until(
+        EC.visibility_of_element_located((By.ID, "signupUsername"))
+    )
+
+    assert driver.find_element(By.ID, "signupUsername").is_displayed()
+    assert driver.find_element(By.ID, "signupEmail").is_displayed()
+    assert driver.find_element(By.ID, "signupPassword").is_displayed()
+
+
+def test_dashboard_redirects_to_login_when_logged_out(driver, live_server_url):
+    driver.get(f"{live_server_url}/dashboard")
+
+    wait_for_page(driver).until(EC.url_contains("/login"))
+    assert "/login" in driver.current_url
+
+
+def test_profile_redirects_to_login_when_logged_out(driver, live_server_url):
+    driver.get(f"{live_server_url}/profile")
+
+    wait_for_page(driver).until(EC.url_contains("/login"))
+    assert "/login" in driver.current_url

--- a/tests/unittest/test_basic_app.py
+++ b/tests/unittest/test_basic_app.py
@@ -1,0 +1,74 @@
+from models import Event, User
+
+
+def login(client, email="gargi@example.com", password="password123"):
+    return client.post(
+        "/login",
+        data={"email": email, "password": password},
+        follow_redirects=True,
+    )
+
+
+def test_login_page_loads_with_csrf_token(client):
+    response = client.get("/login")
+
+    assert response.status_code == 200
+    assert b'name="csrf_token"' in response.data
+
+
+def test_dashboard_redirects_when_not_logged_in(client):
+    response = client.get("/dashboard")
+
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_signup_creates_new_user_in_test_database(client):
+    response = client.post(
+        "/signup",
+        data={
+            "username": "newuser",
+            "email": "newuser@example.com",
+            "password": "Password123",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert User.query.filter_by(email="newuser@example.com").first() is not None
+
+
+def test_logged_in_user_can_create_event(client):
+    login(client)
+
+    response = client.post(
+        "/create-event",
+        json={
+            "title": "Unit Test Event",
+            "type": "Study session",
+            "date": "2026-06-01",
+            "location": "Library",
+            "description": "A small test event",
+            "is_public": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert Event.query.filter_by(title="Unit Test Event").first() is not None
+
+
+def test_profile_update_changes_current_user(client):
+    login(client)
+
+    response = client.post(
+        "/profile/update",
+        json={
+            "username": "updatedgargi",
+            "email": "updatedgargi@example.com",
+        },
+    )
+
+    assert response.status_code == 200
+    user = User.query.filter_by(email="updatedgargi@example.com").first()
+    assert user is not None
+    assert user.username == "updatedgargi"


### PR DESCRIPTION
## Summary

- Require `SECRET_KEY` from environment variables and remove the hardcoded fallback.
- Add a shared Jinja `base.html` layout and refactor pages to use template inheritance.
- Update Selenium setup to use an isolated temporary test database and cross-platform headless browser startup.

## Test plan

- Parsed all Jinja templates successfully.
- Verified changed Python files compile successfully.
- Ran Selenium test setup locally; tests skip cleanly when no Chrome/Edge browser engine is available.
- On Windows, Selenium should run headlessly with Chrome or built-in Edge through Selenium Manager.