### PR TITLE
Timeline reorder in event details page

### DIFF
--- a/app.py
+++ b/app.py
@@ -478,22 +478,38 @@ def get_timeline(event_id):
 @login_required
 def add_timeline(event_id):
     data = request.get_json(silent=True) or {}
-    count = Timeline.query.filter_by(event_id=event_id).count()
+    step_text = data.get("step", "").strip()
+    after_order = data.get("after_order") 
+
+    if not step_text:
+        return jsonify({"error": "Step text is required."}), 400
+
+    if after_order is not None:
+        after_order = int(after_order)
+        Timeline.query.filter_by(event_id=event_id) \
+            .filter(Timeline.order > after_order) \
+            .update({Timeline.order: Timeline.order + 1})
+        
+        new_order = after_order + 1
+    else:
+        count = Timeline.query.filter_by(event_id=event_id).count()
+        new_order = count + 1
 
     step = Timeline(
-        step=data["step"],
-        order=count + 1,
+        step=step_text,
+        order=new_order,
         event_id=event_id
     )
 
     db.session.add(step)
     db.session.commit()
 
-    return jsonify({
-        "id": step.id,
-        "step": step.step,
-        "order": step.order
-    })
+    steps = Timeline.query.filter_by(event_id=event_id).order_by(Timeline.order).all()
+    return jsonify([{
+        "id": s.id,
+        "step": s.step,
+        "order": s.order
+    } for s in steps])
 
 
 @app.route("/timeline/<int:step_id>", methods=["DELETE"])

--- a/static/js/event_details.js
+++ b/static/js/event_details.js
@@ -85,7 +85,6 @@ function openModal(modal)  { modal.classList.remove("hidden"); }
 function closeModal(modal) { modal.classList.add("hidden"); }
 
 openTaskModalBtn.addEventListener("click",        () => openModal(taskModal));
-openTimelineModalBtn.addEventListener("click",    () => openModal(timelineModal));
 openParticipantModalBtn.addEventListener("click", () => openModal(participantModal));
 openPollModalBtn.addEventListener("click",        () => openModal(pollModal));
 
@@ -194,17 +193,55 @@ async function loadTimeline() {
   renderTimeline(steps);
 }
 
+
+openTimelineModalBtn.addEventListener("click", async () => {
+  const res = await fetch(`/event/${EVENT_ID}/timeline`);
+  const steps = await res.json();
+  
+  const positionSelect = document.getElementById("timelinePosition");
+  positionSelect.innerHTML = '<option value="end">At the end</option>';
+  
+  steps.forEach(s => {
+    const option = document.createElement("option");
+    option.value = s.order;
+    option.textContent = `After step ${s.order}: ${s.step.substring(0, 30)}${s.step.length > 30 ? '...' : ''}`;
+    positionSelect.appendChild(option);
+  });
+  
+  openModal(timelineModal);
+});
+
 addTimelineBtn.addEventListener("click", async () => {
   const step = timelineStepInput.value.trim();
   if (!step) return;
-  await csrfFetch(`/event/${EVENT_ID}/timeline`, {
+  
+  const positionSelect = document.getElementById("timelinePosition");
+  const afterOrder = positionSelect.value === "end" ? null : parseInt(positionSelect.value);
+  
+  const res = await csrfFetch(`/event/${EVENT_ID}/timeline`, {
     method:  "POST",
     headers: { "Content-Type": "application/json" },
-    body:    JSON.stringify({ step })
+    body:    JSON.stringify({ 
+      step: step,
+      after_order: afterOrder
+    })
   });
+  
+  const data = await res.json();
+  
+  if (data.error) {
+    alert(data.error);
+    return;
+  }
+  
+  if (Array.isArray(data)) {
+    renderTimeline(data);
+  } else {
+    loadTimeline();
+  }
+  
   timelineStepInput.value = "";
   closeModal(timelineModal);
-  loadTimeline();
 });
 
 /* PARTICIPANTS */

--- a/templates/event_details.html
+++ b/templates/event_details.html
@@ -223,6 +223,12 @@
         <label for="timelineStep">Step description</label>
         <input id="timelineStep" type="text" placeholder="e.g. Arrive at beach at 10am" />
       </div>
+      <div class="field-group">
+        <label for="timelinePosition">Insert position</label>
+        <select id="timelinePosition">
+          <option value="end">At the end</option>
+        </select>
+      </div>
     </div>
     <div class="modal-footer">
       <button class="action-btn btn-timeline" id="addTimelineBtn" type="button">Add Step</button>


### PR DESCRIPTION
Previously, the timeline feature in the event details page only allowed users to add steps to the end of the timeline (e.g. after step 3, you could only add step 4). This PR enables users to insert new steps at any position within the timeline, with automatic reordering of subsequent steps.

● Backend Changes(`app.py`)
Modified `POST /event/<id>/timeline` to accept an optional `after_order` parameter and shift later steps when inserting

● Frontend Changes (`event_details.html`)
Added a position selector dropdown to the timeline modal

● Frontend Changes (`event_details.js`)
Updated modal to populate position options dynamically and send `after_order` when adding a step