### PR TITLE
fix small error relating to timeline in event_details.js

### DIFF
--- a/static/js/event_details.js
+++ b/static/js/event_details.js
@@ -260,12 +260,14 @@ addTimelineBtn.addEventListener("click", async () => {
   if (!step) return;
   
   const positionSelect = document.getElementById("timelinePosition");
-  const afterOrder = positionSelect.value === "end" ? null : parseInt(positionSelect.value);
+  const afterOrder = positionSelect.value === "end"
+    ? null
+    : parseInt(positionSelect.value);
   
-  const res = await csrfFetch(`/event/${EVENT_ID}/timeline`, {
-    method:  "POST",
+  const res = await fetch(`/event/${EVENT_ID}/timeline`, {
+    method: "POST",
     headers: { "Content-Type": "application/json" },
-    body:    JSON.stringify({ 
+    body: JSON.stringify({ 
       step: step,
       after_order: afterOrder
     })


### PR DESCRIPTION
Fixed timeline step creation issue by replacing undefined csrfFetch() with standard fetch() in event_details.js. This resolved the modal freezing and allowed timeline steps to be added correctly.